### PR TITLE
[Feat] Supabase 인증 초기 연결

### DIFF
--- a/apps/web/app/login/bootstrap/route.ts
+++ b/apps/web/app/login/bootstrap/route.ts
@@ -9,12 +9,21 @@ export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function GET(request: Request) {
-  const { playerId, shouldSetCookie } = await ensurePlayerSession();
-  const response = NextResponse.redirect(new URL("/login", request.url));
+  try {
+    const { playerId, shouldSetCookie } = await ensurePlayerSession();
+    const response = NextResponse.redirect(new URL("/login", request.url));
 
-  if (shouldSetCookie) {
-    response.cookies.set(PLAYER_SESSION_COOKIE_NAME, playerId, playerSessionCookieOptions);
+    if (shouldSetCookie) {
+      response.cookies.set(PLAYER_SESSION_COOKIE_NAME, playerId, playerSessionCookieOptions);
+    }
+
+    return response;
+  } catch (error) {
+    console.error("Failed to bootstrap player session.", error);
+
+    const loginUrl = new URL("/login", request.url);
+    loginUrl.searchParams.set("error", "session-init-failed");
+
+    return NextResponse.redirect(loginUrl);
   }
-
-  return response;
 }

--- a/apps/web/app/login/bootstrap/route.ts
+++ b/apps/web/app/login/bootstrap/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import {
+  ensurePlayerSession,
+  PLAYER_SESSION_COOKIE_NAME,
+  playerSessionCookieOptions,
+} from "@/shared/lib/server/player-session";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(request: Request) {
+  const { playerId, shouldSetCookie } = await ensurePlayerSession();
+  const response = NextResponse.redirect(new URL("/login", request.url));
+
+  if (shouldSetCookie) {
+    response.cookies.set(PLAYER_SESSION_COOKIE_NAME, playerId, playerSessionCookieOptions);
+  }
+
+  return response;
+}

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -1,5 +1,15 @@
 import { LoginPage } from "@/pages/login";
+import { getCurrentPlayerId } from "@/shared/lib/server/player-session";
+import { redirect } from "next/navigation";
 
-export default function Page() {
+export const dynamic = "force-dynamic";
+
+export default async function Page() {
+  const playerId = await getCurrentPlayerId();
+
+  if (!playerId) {
+    redirect("/login/bootstrap");
+  }
+
   return <LoginPage />;
 }

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -4,12 +4,29 @@ import { redirect } from "next/navigation";
 
 export const dynamic = "force-dynamic";
 
-export default async function Page() {
-  const playerId = await getCurrentPlayerId();
+interface LoginPageProps {
+  searchParams: Promise<{
+    error?: string;
+  }>;
+}
 
-  if (!playerId) {
+export default async function Page({ searchParams }: LoginPageProps) {
+  const { error } = await searchParams;
+  let playerId: string | null = null;
+  let pageError = error;
+
+  try {
+    playerId = await getCurrentPlayerId();
+  } catch {
+    pageError = "session-load-failed";
+  }
+
+  const hasSessionError =
+    pageError === "session-init-failed" || pageError === "session-load-failed";
+
+  if (!playerId && !hasSessionError) {
     redirect("/login/bootstrap");
   }
 
-  return <LoginPage />;
+  return <LoginPage error={pageError} />;
 }

--- a/apps/web/src/pages/login/ui/LoginForm.tsx
+++ b/apps/web/src/pages/login/ui/LoginForm.tsx
@@ -49,7 +49,7 @@ export function LoginForm() {
           <Input
             id="employee-id"
             type="text"
-            placeholder="aegis-0123"
+            placeholder="아이디를 입력하세요"
             className="pl-10"
             autoComplete="username"
             aria-invalid={hasError}

--- a/apps/web/src/pages/login/ui/LoginForm.tsx
+++ b/apps/web/src/pages/login/ui/LoginForm.tsx
@@ -6,7 +6,16 @@ import { ArrowRight, KeyRound, UserRound } from "lucide-react";
 import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
 
-export function LoginForm() {
+interface LoginFormProps {
+  error?: string;
+}
+
+const sessionBootstrapErrorMessage =
+  "세션을 준비하지 못했습니다. 잠시 후 다시 시도하거나 관리자에게 문의하세요.";
+const sessionLoadErrorMessage =
+  "기존 세션을 확인하지 못했습니다. 잠시 후 다시 시도하거나 관리자에게 문의하세요.";
+
+export function LoginForm({ error }: LoginFormProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [employeeId, setEmployeeId] = useState("");
@@ -15,7 +24,14 @@ export function LoginForm() {
   const demoEmployeeId = process.env.NEXT_PUBLIC_DEMO_EMPLOYEE_ID;
   const demoEmployeePassword = process.env.NEXT_PUBLIC_DEMO_EMPLOYEE_PASSWORD;
   const errorMessageId = "login-error";
-  const hasError = Boolean(errorMessage);
+  const serverErrorMessage =
+    error === "session-init-failed"
+      ? sessionBootstrapErrorMessage
+      : error === "session-load-failed"
+        ? sessionLoadErrorMessage
+        : "";
+  const visibleErrorMessage = errorMessage || serverErrorMessage;
+  const hasError = Boolean(visibleErrorMessage);
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -99,7 +115,7 @@ export function LoginForm() {
           aria-live="assertive"
           className="rounded-2xl border border-rose-100 bg-rose-50 px-4 py-3 text-sm text-rose-900"
         >
-          {errorMessage}
+          {visibleErrorMessage}
         </div>
       ) : null}
 

--- a/apps/web/src/pages/login/ui/LoginPage.tsx
+++ b/apps/web/src/pages/login/ui/LoginPage.tsx
@@ -1,7 +1,11 @@
 import { BadgeCheck, Building2, ShieldCheck } from "lucide-react";
 import { LoginForm } from "./LoginForm";
 
-export function LoginPage() {
+interface LoginPageProps {
+  error?: string;
+}
+
+export function LoginPage({ error }: LoginPageProps) {
   return (
     <main className="relative min-h-screen overflow-hidden bg-linear-to-br from-slate-100 via-sky-50 to-cyan-100 px-4 py-10 text-slate-900 sm:px-6 lg:px-8">
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(14,165,233,0.18),_transparent_32%),radial-gradient(circle_at_bottom_right,_rgba(16,185,129,0.15),_transparent_28%)]" />
@@ -86,7 +90,7 @@ export function LoginPage() {
             </p>
           </div>
 
-          <LoginForm />
+          <LoginForm error={error} />
 
           <div className="mt-8 flex items-center justify-between border-t border-slate-200 pt-5 text-xs text-slate-500">
             <span>System Status: Online</span>

--- a/apps/web/src/shared/lib/server/player-session.ts
+++ b/apps/web/src/shared/lib/server/player-session.ts
@@ -43,16 +43,21 @@ async function createPlayer() {
 }
 
 export async function getCurrentPlayerId() {
-  const cookieStore = await cookies();
-  const playerId = cookieStore.get(PLAYER_SESSION_COOKIE_NAME)?.value;
+  try {
+    const cookieStore = await cookies();
+    const playerId = cookieStore.get(PLAYER_SESSION_COOKIE_NAME)?.value;
 
-  if (!playerId || !isValidPlayerId(playerId)) {
-    return null;
+    if (!playerId || !isValidPlayerId(playerId)) {
+      return null;
+    }
+
+    const player = await findPlayerById(playerId);
+
+    return player?.id ?? null;
+  } catch (error) {
+    console.error("Failed to resolve current player session.", error);
+    throw new Error("Failed to resolve current player session.");
   }
-
-  const player = await findPlayerById(playerId);
-
-  return player?.id ?? null;
 }
 
 export async function ensurePlayerSession() {

--- a/apps/web/src/shared/lib/server/player-session.ts
+++ b/apps/web/src/shared/lib/server/player-session.ts
@@ -1,0 +1,79 @@
+import "server-only";
+
+import { cookies } from "next/headers";
+import { createServerSupabaseAdminClient } from "./supabase";
+
+const playerIdPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export const PLAYER_SESSION_COOKIE_NAME = "pe_player_session";
+
+export const playerSessionCookieOptions = {
+  httpOnly: true,
+  maxAge: 60 * 60 * 24 * 365,
+  path: "/",
+  sameSite: "lax" as const,
+  secure: process.env.NODE_ENV === "production",
+};
+
+function isValidPlayerId(value: string | undefined) {
+  return Boolean(value && playerIdPattern.test(value));
+}
+
+async function findPlayerById(playerId: string) {
+  const supabase = createServerSupabaseAdminClient();
+  const { data, error } = await supabase.from("players").select("id").eq("id", playerId).maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load player session: ${error.message}`);
+  }
+
+  return data;
+}
+
+async function createPlayer() {
+  const supabase = createServerSupabaseAdminClient();
+  const { data, error } = await supabase.from("players").insert({}).select("id").single();
+
+  if (error || !data) {
+    throw new Error(`Failed to create player session: ${error?.message ?? "unknown error"}`);
+  }
+
+  return data;
+}
+
+export async function getCurrentPlayerId() {
+  const cookieStore = await cookies();
+  const playerId = cookieStore.get(PLAYER_SESSION_COOKIE_NAME)?.value;
+
+  if (!playerId || !isValidPlayerId(playerId)) {
+    return null;
+  }
+
+  const player = await findPlayerById(playerId);
+
+  return player?.id ?? null;
+}
+
+export async function ensurePlayerSession() {
+  const cookieStore = await cookies();
+  const existingPlayerId = cookieStore.get(PLAYER_SESSION_COOKIE_NAME)?.value;
+
+  if (existingPlayerId && isValidPlayerId(existingPlayerId)) {
+    const existingPlayer = await findPlayerById(existingPlayerId);
+
+    if (existingPlayer) {
+      return {
+        playerId: existingPlayer.id,
+        shouldSetCookie: false,
+      };
+    }
+  }
+
+  const player = await createPlayer();
+
+  return {
+    playerId: player.id,
+    shouldSetCookie: true,
+  };
+}

--- a/apps/web/src/shared/lib/server/supabase.ts
+++ b/apps/web/src/shared/lib/server/supabase.ts
@@ -1,0 +1,26 @@
+import "server-only";
+
+import { createClient } from "@supabase/supabase-js";
+
+function getRequiredServerEnv(name: string) {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`${name} is required to access Supabase from the server.`);
+  }
+
+  return value;
+}
+
+export function createServerSupabaseAdminClient() {
+  const supabaseUrl =
+    process.env.NEXT_PUBLIC_SUPABASE_URL ?? getRequiredServerEnv("SUPABASE_URL");
+  const serviceRoleKey = getRequiredServerEnv("SUPABASE_SERVICE_ROLE_KEY");
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}

--- a/supabase/migrations/20260402091531_create_quests.sql
+++ b/supabase/migrations/20260402091531_create_quests.sql
@@ -1,0 +1,35 @@
+do $$
+begin
+  if not exists (
+    select 1 from pg_type where typname = 'quest_type'
+  ) then
+    create type public.quest_type as enum ('main', 'sub');
+  end if;
+end
+$$;
+
+create table if not exists public.quests (
+  id bigint generated always as identity primary key,
+  quest_id text not null unique,
+  quest_number integer unique,
+  name text not null,
+  description text,
+  quest_type public.quest_type not null,
+  completion_condition text not null
+);
+
+insert into public.quests (
+  quest_id,
+  quest_number,
+  name,
+  description,
+  quest_type,
+  completion_condition
+) values (
+  'login_success',
+  1,
+  '비밀의 기업',
+  '이지스 인프라스트럭쳐 인트라넷에 접속했다.',
+  'main',
+  'story_login_success'
+);

--- a/supabase/migrations/20260405065000_replace_user_profiles_with_players.sql
+++ b/supabase/migrations/20260405065000_replace_user_profiles_with_players.sql
@@ -1,0 +1,32 @@
+alter table if exists public.comments
+  drop constraint if exists comments_author_id_fkey;
+
+alter table if exists public.posts
+  drop constraint if exists posts_author_id_fkey;
+
+drop trigger if exists trg_user_profiles_updated_at on public.user_profiles;
+
+drop index if exists public.idx_user_profiles_auth_user_id;
+
+drop table if exists public.user_profiles;
+
+create table if not exists public.players (
+  id uuid primary key default gen_random_uuid(),
+  auth_user_id uuid unique references auth.users (id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_players_auth_user_id
+  on public.players (auth_user_id);
+
+create or replace trigger trg_players_updated_at
+before update on public.players
+for each row
+execute function public.set_updated_at();
+
+alter table public.players enable row level security;
+
+grant all on table public.players to anon;
+grant all on table public.players to authenticated;
+grant all on table public.players to service_role;

--- a/supabase/migrations/20260405065958_create_player_quest_progress.sql
+++ b/supabase/migrations/20260405065958_create_player_quest_progress.sql
@@ -1,0 +1,26 @@
+do $$
+begin
+  if not exists (
+    select 1 from pg_type where typname = 'quest_progress_status'
+  ) then
+    create type public.quest_progress_status as enum ('active', 'completed');
+  end if;
+end
+$$;
+
+create table if not exists public.player_quest_progress (
+  id bigint generated always as identity primary key,
+  player_id uuid not null references public.players (id) on delete cascade,
+  quest_id text not null references public.quests (quest_id) on delete cascade,
+  status public.quest_progress_status not null,
+  completed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  unique (player_id, quest_id)
+);
+
+create or replace trigger trg_player_quest_progress_updated_at
+before update on public.player_quest_progress
+for each row
+execute function public.set_updated_at();

--- a/supabase/migrations/20260405100500_fix_player_quest_progress_player_fk.sql
+++ b/supabase/migrations/20260405100500_fix_player_quest_progress_player_fk.sql
@@ -1,0 +1,8 @@
+alter table if exists public.player_quest_progress
+  drop constraint if exists player_quest_progress_player_id_fkey;
+
+alter table if exists public.player_quest_progress
+  add constraint player_quest_progress_player_id_fkey
+  foreign key (player_id)
+  references public.players (id)
+  on delete cascade;

--- a/supabase/migrations/20260405101000_assign_initial_login_quest_to_players.sql
+++ b/supabase/migrations/20260405101000_assign_initial_login_quest_to_players.sql
@@ -1,0 +1,36 @@
+create or replace function public.assign_initial_login_quest()
+returns trigger
+language plpgsql
+as $$
+begin
+  insert into public.player_quest_progress (
+    player_id,
+    quest_id,
+    status
+  ) values (
+    new.id,
+    'login_success',
+    'active'
+  )
+  on conflict (player_id, quest_id) do nothing;
+
+  return new;
+end;
+$$;
+
+create or replace trigger trg_players_assign_initial_login_quest
+after insert on public.players
+for each row
+execute function public.assign_initial_login_quest();
+
+insert into public.player_quest_progress (
+  player_id,
+  quest_id,
+  status
+)
+select
+  players.id,
+  'login_success',
+  'active'
+from public.players
+on conflict (player_id, quest_id) do nothing;


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- Supabase 인증 초기 연결을 위한 서버 유틸과 플레이어 세션 부트스트랩 흐름을 구성했습니다.
- 로그인 진입 시 플레이어 세션을 안정적으로 보장할 수 있도록 최소한의 퀘스트 기반 스키마도 함께 정리했습니다.

## ✨ 변경 사항 (Changes)

- 서버에서 사용할 Supabase admin client 유틸을 추가했습니다.
- 플레이어 세션 조회 및 생성 로직과 로그인 부트스트랩 route handler를 추가했습니다.
- `players`, `quests`, `player_quest_progress` 관련 Supabase 마이그레이션을 추가했습니다.
- 로그인 폼의 아이디 placeholder 문구를 현재 UI 톤에 맞게 정리했습니다.

## 📸 스크린샷 (Screenshots)

- UI 스크린샷 변경 없음

## 📢 참고 사항 (Notes)

- 로그인 성공 시 퀘스트 완료 처리와 공용 완료 애니메이션은 후속 이슈로 분리 예정입니다.
- 검증: `pnpm --filter web lint`, `pnpm --filter web check-types`

## 🧐 이슈 (Related Issues)

- Closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 자동 세션 생성 및 로그인 리다이렉트 흐름 추가 (세션 쿠키 설정 포함)
  * 로그인 페이지가 서버에서 동적으로 처리되며 외부 세션 오류를 UI에 표시
  * 퀘스트 시스템 도입 및 플레이어 퀘스트 진행 테이블 추가
  * 플레이어 프로필 테이블 도입 및 기존 프로필 교체, 신규 플레이어에 로그인 퀘스트 자동 할당

* **로컬라이제이션**
  * 로그인 폼의 플레이어 아이디 플레이스홀더 한국어로 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->