### PR TITLE
[Feat] 로그인 진입 경험 구조 정리

### DIFF
--- a/apps/web/src/pages/login/model/useLoginForm.ts
+++ b/apps/web/src/pages/login/model/useLoginForm.ts
@@ -1,0 +1,114 @@
+"use client";
+
+import { type FormEvent, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { completeLoginSuccessQuestAction } from "./complete-login-success-quest";
+import { useQuestCelebration } from "@/shared/lib/quest-celebration";
+
+const sessionBootstrapErrorMessage =
+  "세션을 준비하지 못했습니다. 잠시 후 다시 시도하거나 관리자에게 문의하세요.";
+const sessionLoadErrorMessage =
+  "기존 세션을 확인하지 못했습니다. 잠시 후 다시 시도하거나 관리자에게 문의하세요.";
+const loginQuestUnexpectedErrorMessage =
+  "로그인 처리 중 문제가 발생했습니다. 잠시 후 다시 시도하거나 관리자에게 문의하세요.";
+const missingCredentialErrorMessage =
+  "로그인 계정이 아직 설정되지 않았습니다. 관리자에게 문의하세요.";
+const invalidCredentialErrorMessage =
+  "계정 정보가 일치하지 않습니다. 인사팀에서 전달된 정보를 다시 확인하세요.";
+
+function getServerErrorMessage(error?: string) {
+  if (error === "session-init-failed") {
+    return sessionBootstrapErrorMessage;
+  }
+
+  if (error === "session-load-failed") {
+    return sessionLoadErrorMessage;
+  }
+
+  return "";
+}
+
+function getCredentialErrorMessage(employeeId: string, password: string) {
+  const demoEmployeeId = process.env.NEXT_PUBLIC_DEMO_EMPLOYEE_ID;
+  const demoEmployeePassword = process.env.NEXT_PUBLIC_DEMO_EMPLOYEE_PASSWORD;
+
+  if (!demoEmployeeId || !demoEmployeePassword) {
+    return missingCredentialErrorMessage;
+  }
+
+  const isValidCredential = employeeId === demoEmployeeId && password === demoEmployeePassword;
+
+  if (!isValidCredential) {
+    return invalidCredentialErrorMessage;
+  }
+
+  return "";
+}
+
+interface UseLoginFormOptions {
+  error?: string;
+}
+
+export function useLoginForm({ error }: UseLoginFormOptions) {
+  const router = useRouter();
+  const { celebrate } = useQuestCelebration();
+  const [isPending, startTransition] = useTransition();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [employeeId, setEmployeeId] = useState("");
+  const [password, setPassword] = useState("");
+  const [clientErrorMessage, setClientErrorMessage] = useState("");
+
+  const serverErrorMessage = getServerErrorMessage(error);
+  const errorMessage = clientErrorMessage || serverErrorMessage;
+  const hasError = Boolean(errorMessage);
+  const isBusy = isSubmitting || isPending;
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (isBusy) {
+      return;
+    }
+
+    const nextErrorMessage = getCredentialErrorMessage(employeeId, password);
+
+    if (nextErrorMessage) {
+      setClientErrorMessage(nextErrorMessage);
+      return;
+    }
+
+    setClientErrorMessage("");
+    setIsSubmitting(true);
+
+    try {
+      const result = await completeLoginSuccessQuestAction();
+
+      if (result.error) {
+        setClientErrorMessage(result.error);
+        return;
+      }
+
+      celebrate(result.completedQuests);
+
+      startTransition(() => {
+        router.replace("/");
+      });
+    } catch (error) {
+      console.error("Failed to submit login form.", error);
+      setClientErrorMessage(loginQuestUnexpectedErrorMessage);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return {
+    employeeId,
+    password,
+    errorMessage,
+    hasError,
+    isBusy,
+    setEmployeeId,
+    setPassword,
+    handleSubmit,
+  };
+}

--- a/apps/web/src/pages/login/ui/LoginForm.tsx
+++ b/apps/web/src/pages/login/ui/LoginForm.tsx
@@ -1,10 +1,7 @@
 "use client";
 
-import { useState, useTransition } from "react";
-import { useRouter } from "next/navigation";
 import { ArrowRight, KeyRound, LoaderCircle, UserRound } from "lucide-react";
-import { completeLoginSuccessQuestAction } from "../model/complete-login-success-quest";
-import { useQuestCelebration } from "@/shared/lib/quest-celebration";
+import { useLoginForm } from "../model/useLoginForm";
 import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
 
@@ -12,76 +9,18 @@ interface LoginFormProps {
   error?: string;
 }
 
-const sessionBootstrapErrorMessage =
-  "세션을 준비하지 못했습니다. 잠시 후 다시 시도하거나 관리자에게 문의하세요.";
-const sessionLoadErrorMessage =
-  "기존 세션을 확인하지 못했습니다. 잠시 후 다시 시도하거나 관리자에게 문의하세요.";
-const loginQuestUnexpectedErrorMessage =
-  "로그인 처리 중 문제가 발생했습니다. 잠시 후 다시 시도하거나 관리자에게 문의하세요.";
-
 export function LoginForm({ error }: LoginFormProps) {
-  const router = useRouter();
-  const { celebrate } = useQuestCelebration();
-  const [isPending, startTransition] = useTransition();
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [employeeId, setEmployeeId] = useState("");
-  const [password, setPassword] = useState("");
-  const [errorMessage, setErrorMessage] = useState("");
-  const demoEmployeeId = process.env.NEXT_PUBLIC_DEMO_EMPLOYEE_ID;
-  const demoEmployeePassword = process.env.NEXT_PUBLIC_DEMO_EMPLOYEE_PASSWORD;
   const errorMessageId = "login-error";
-  const serverErrorMessage =
-    error === "session-init-failed"
-      ? sessionBootstrapErrorMessage
-      : error === "session-load-failed"
-        ? sessionLoadErrorMessage
-        : "";
-  const visibleErrorMessage = errorMessage || serverErrorMessage;
-  const hasError = Boolean(visibleErrorMessage);
-  const isBusy = isSubmitting || isPending;
-
-  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-
-    if (isBusy) {
-      return;
-    }
-
-    if (!demoEmployeeId || !demoEmployeePassword) {
-      setErrorMessage("로그인 계정이 아직 설정되지 않았습니다. 관리자에게 문의하세요.");
-      return;
-    }
-
-    const isValidCredential = employeeId === demoEmployeeId && password === demoEmployeePassword;
-
-    if (!isValidCredential) {
-      setErrorMessage("계정 정보가 일치하지 않습니다. 인사팀에서 전달된 정보를 다시 확인하세요.");
-      return;
-    }
-
-    setErrorMessage("");
-    setIsSubmitting(true);
-
-    try {
-      const result = await completeLoginSuccessQuestAction();
-
-      if (result.error) {
-        setErrorMessage(result.error);
-        return;
-      }
-
-      celebrate(result.completedQuests);
-
-      startTransition(() => {
-        router.replace("/");
-      });
-    } catch (error) {
-      console.error("Failed to submit login form.", error);
-      setErrorMessage(loginQuestUnexpectedErrorMessage);
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
+  const {
+    employeeId,
+    password,
+    errorMessage,
+    hasError,
+    isBusy,
+    setEmployeeId,
+    setPassword,
+    handleSubmit,
+  } = useLoginForm({ error });
 
   return (
     <form className="mt-8 space-y-5" onSubmit={handleSubmit} aria-busy={isBusy}>
@@ -146,7 +85,7 @@ export function LoginForm({ error }: LoginFormProps) {
           aria-live="assertive"
           className="rounded-2xl border border-rose-100 bg-rose-50 px-4 py-3 text-sm text-rose-900"
         >
-          {visibleErrorMessage}
+          {errorMessage}
         </div>
       ) : null}
 


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 로그인 진입 경험 관련 코드 구조를 정리했습니다.
- `LoginForm`에 몰려 있던 상태/에러/제출 로직을 분리해 화면 컴포넌트를 더 읽기 쉬운 형태로 정돈했습니다.

## ✨ 변경 사항 (Changes)

- `useLoginForm` 커스텀 훅을 추가해 로그인 폼 상태와 제출 로직을 분리했습니다.
- `LoginForm`이 훅 결과를 받아 UI 렌더링과 입력 바인딩에 집중하도록 정리했습니다.
- 서버 에러 메시지와 자격 증명 검증 흐름을 훅 내부의 작은 함수들로 정리했습니다.

## 📸 스크린샷 (Screenshots)

- UI 변경 없음

## 📢 참고 사항 (Notes)

- `pnpm --filter web lint`
- `pnpm --filter web check-types`

## 🧐 이슈 (Related Issues)

- Closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **리팩터**
  * 로그인 폼 컴포넌트의 상태 관리 및 제출 로직을 분리된 훅으로 재구성하여 코드 조직을 개선했습니다. 사용자 자격 증명 검증, 오류 처리, 네비게이션 로직이 중앙에서 관리되도록 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->